### PR TITLE
Make directories that will be included in check, configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+## 1.1.0
+- Made directories that will be checked under pom (child) projects configurable. It is possible to use * to include all directories. Default if not set, is `src` directory as before. See [README.md](README.md)
+     ```xml
+      <includeTopDirectories>*</includeTopDirectories>
+- Also made it possible to exclude directories. * can not be used. Default if not set, nothing will be excluded.
+    ```xml
+    <excludeTopDirectories>target,node_modules</excludeTopDirectories>
+- Bugfix so that `ignoreChangesInFiles` can contain more than one file (comma separated).
+
+## 1.0.0
+- Initial version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+## 1.1.0
+- Made directories that will be checked under pom (child) projects configurable. It is possible to use * to include all directories. Default if not set, is `src` directory as before. See [README.md](README.md)
+     ```xml
+      <includeTopDirectories>*</includeTopDirectories>
+- Also made it possible to exclude directories. * can not be used. Default if not set, nothing will be excluded.
+    ```xml
+    <excludeTopDirectories>target,node_modules</excludeTopDirectories>
+- Fix so that `ignoreChangesInFiles` can contain more than one file (comma separated).
+
+## 1.0.0
+- Initial version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Also made it possible to exclude directories. * can not be used. Default if not set, nothing will be excluded.
     ```xml
     <excludeTopDirectories>target,node_modules</excludeTopDirectories>
-- Bugfix so that `ignoreChangesInFiles` can contain more than one file (comma separated).
+- Fix so that `ignoreChangesInFiles` can contain more than one file (comma separated).
 
 ## 1.0.0
 - Initial version

--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ A maven plugin that turbo charges your Maven build by only building the projects
  ## Usage
  The plugin has the following parameters:
  
- |parameter name| description                                                                                                                  |default value|
- |------------------------------------------------------------------------------------------------------------------------------|------------|-------------|
- | enabled  | Enables of disables the plugin.                                                                                              | true |
- | alwaysBuildModules  | Always build the specified modules. Comma separated. Checked only by doing a contains of the file name in this string        | empty string |
- | ignoreChangesInFiles | Skips build even these files have changed. Comma separated. Checked only by doing a contains of the file name in this string | empty string |
+ |parameter name| description                                                                                                                                                                     | default value |
+ |------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+ | enabled  | Enables of disables the plugin.                                                                                                                                                 | true          |
+ | alwaysBuildModules  | Always build the specified modules. Comma separated. Checked only by doing a contains of the file name in this string                                                           | empty string  |
+ | ignoreChangesInFiles | Skips build even these files have changed. Comma separated.                                                                                                                     | empty string  |
+ | includeTopDirectories | Specify which top directories under pom (child) project that will be included in check. Use * to include all. Comma separated. If not used, only src directory will be included | src           |
+ | excludeTopDirectories | Specify which top directories under pom (child) project that will be excluded in check. Comma separated. If not used, nothing explicit will be excluded                         | empty string  |
  
  ### Command line parameters
  The parameters can be set on the command line. They will have precedence over the parameters in the plugin configuration.
@@ -38,6 +40,24 @@ mvn clean install -Dturbo.enabled=false
     </configuration>
 </plugin>
 ```
+
+### Example of more advanced plugin configuration:
+ ```
+ <plugin>
+    <groupId>no.sparebank1</groupId>
+    <artifactId>turbo-maven-plugin</artifactId>
+    <version>${maven-turbo-plugin.version}</version>
+    <extensions>true</extensions>
+    <configuration>
+        <enabled>true</enabled>
+        <ignoreChangesInFiles>swagger.json,.versionsBackup,.jar</ignoreChangesInFiles>
+        <alwaysBuildModules>distribution</alwaysBuildModules>
+        <includeTopDirectories>*</includeTopDirectories>
+        <excludeTopDirectories>target,node_modules</excludeTopDirectories>
+    </configuration>
+</plugin>
+```
+
 You typically add the plugin to the plugins section of your root pom. 
 
 #### Building with the plugin enabled

--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ A maven plugin that turbo charges your Maven build by only building the projects
  ## Usage
  The plugin has the following parameters:
  
- |parameter name| description                                                                                                                  |default value|
- |------------------------------------------------------------------------------------------------------------------------------|------------|-------------|
- | enabled  | Enables of disables the plugin.                                                                                              | true |
- | alwaysBuildModules  | Always build the specified modules. Comma separated. Checked only by doing a contains of the file name in this string        | empty string |
- | ignoreChangesInFiles | Skips build even these files have changed. Comma separated. Checked only by doing a contains of the file name in this string | empty string |
+ |parameter name| description                                                                                                                                                                           | default value |
+ |------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+ | enabled  | Enables of disables the plugin.                                                                                                                                                       | true          |
+ | alwaysBuildModules  | Always build the specified modules. Comma separated. Checked only by doing a contains of the file name in this string                                                                 | empty string  |
+ | ignoreChangesInFiles | Skips build even these files have changed. Comma separated. Checked only by doing a contains of the file name in this string                                                          | empty string  |
+ | includeTopDirectories | Possibility to specify which top directories under pom (child) project that will be included. Use * to include all. Comma separated. If not used, only src directory will be included | src           |
+ | excludeTopDirectories | Possibility to specify which top directories under pom (child) project that will be excluded. Comma separated. If not used, nothing explicit will be excluded                          | empty string  |
  
  ### Command line parameters
  The parameters can be set on the command line. They will have precedence over the parameters in the plugin configuration.
@@ -38,6 +40,24 @@ mvn clean install -Dturbo.enabled=false
     </configuration>
 </plugin>
 ```
+
+### Example of more advanced plugin configuration:
+ ```
+ <plugin>
+    <groupId>no.sparebank1</groupId>
+    <artifactId>turbo-maven-plugin</artifactId>
+    <version>${maven-turbo-plugin.version}</version>
+    <extensions>true</extensions>
+    <configuration>
+        <enabled>true</enabled>
+        <ignoreChangesInFiles>swagger.json,.versionsBackup,.jar</ignoreChangesInFiles>
+        <alwaysBuildModules>distribution</alwaysBuildModules>
+        <includeTopDirectories>*</includeTopDirectories>
+        <excludeTopDirectories>target,node_modules</excludeTopDirectories>
+    </configuration>
+</plugin>
+```
+
 You typically add the plugin to the plugins section of your root pom. 
 
 #### Building with the plugin enabled

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ A maven plugin that turbo charges your Maven build by only building the projects
  ## Usage
  The plugin has the following parameters:
  
- |parameter name| description                                                                                                                                                                           | default value |
- |------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
- | enabled  | Enables of disables the plugin.                                                                                                                                                       | true          |
- | alwaysBuildModules  | Always build the specified modules. Comma separated. Checked only by doing a contains of the file name in this string                                                                 | empty string  |
- | ignoreChangesInFiles | Skips build even these files have changed. Comma separated. Checked only by doing a contains of the file name in this string                                                          | empty string  |
- | includeTopDirectories | Possibility to specify which top directories under pom (child) project that will be included. Use * to include all. Comma separated. If not used, only src directory will be included | src           |
- | excludeTopDirectories | Possibility to specify which top directories under pom (child) project that will be excluded. Comma separated. If not used, nothing explicit will be excluded                          | empty string  |
+ |parameter name| description                                                                                                                                                                     | default value |
+ |------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+ | enabled  | Enables of disables the plugin.                                                                                                                                                 | true          |
+ | alwaysBuildModules  | Always build the specified modules. Comma separated. Checked only by doing a contains of the file name in this string                                                           | empty string  |
+ | ignoreChangesInFiles | Skips build even these files have changed. Comma separated.                                                                                                                     | empty string  |
+ | includeTopDirectories | Specify which top directories under pom (child) project that will be included in check. Use * to include all. Comma separated. If not used, only src directory will be included | src           |
+ | excludeTopDirectories | Specify which top directories under pom (child) project that will be excluded in check. Comma separated. If not used, nothing explicit will be excluded                         | empty string  |
  
  ### Command line parameters
  The parameters can be set on the command line. They will have precedence over the parameters in the plugin configuration.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>no.sparebank1</groupId>
     <artifactId>turbo-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>1.0.0</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <name>turbo-maven-plugin Maven Mojo</name>
     <description>

--- a/src/main/java/no/sparebank1/turbo/ProjectsAnalyzer.java
+++ b/src/main/java/no/sparebank1/turbo/ProjectsAnalyzer.java
@@ -17,11 +17,11 @@ public class ProjectsAnalyzer {
     this.sourceFileFinder = sourceFileFinder;
   }
 
-  public List<MavenProject> calculateProjectsToBuild(final String m2Repository, final List<MavenProject> projects, final ProjectDependencyGraph projectDependencyGraph, final String ignoreChangesInFiles, final String alwaysBuildModules) {
+  public List<MavenProject> calculateProjectsToBuild(final String m2Repository, final List<MavenProject> projects, final ProjectDependencyGraph projectDependencyGraph, final String ignoreChangesInFiles, final String alwaysBuildModules, final String includeTopDirectories, final String excludeTopDirectories) {
 
     //Get the projects that require a new build:
     List<MavenProject> projectsToBuild = projects.stream()
-      .filter(project -> shallBuildProject(m2Repository, project, ignoreChangesInFiles, alwaysBuildModules))
+      .filter(project -> shallBuildProject(m2Repository, project, ignoreChangesInFiles, alwaysBuildModules, includeTopDirectories, excludeTopDirectories))
       .distinct()
       .collect(Collectors.toList());
 
@@ -36,8 +36,8 @@ public class ProjectsAnalyzer {
       .collect(Collectors.toList());
   }
 
-  protected boolean shallBuildProject(final String m2Repository, final MavenProject project, final String ignoreChangesInFiles, final String alwaysBuildModules) {
-    List<String> sourceFiles = sourceFileFinder.getSourceFiles(project.getBasedir().getAbsolutePath(), ignoreChangesInFiles);
+  protected boolean shallBuildProject(final String m2Repository, final MavenProject project, final String ignoreChangesInFiles, final String alwaysBuildModules, final String includeTopDirectories, final String excludeTopDirectories) {
+    List<String> sourceFiles = sourceFileFinder.getSourceFiles(project.getBasedir().getAbsolutePath(), project.getModules(), ignoreChangesInFiles, includeTopDirectories, excludeTopDirectories);
     return artifactAnalyzer.shallBuild(m2Repository, sourceFiles, project.getGroupId(), project.getArtifactId(), project.getVersion(), project.getPackaging(), alwaysBuildModules);
   }
 }

--- a/src/main/java/no/sparebank1/turbo/TurboConfig.java
+++ b/src/main/java/no/sparebank1/turbo/TurboConfig.java
@@ -4,9 +4,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import javax.inject.Inject;
-
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Plugin;
 
@@ -21,6 +18,8 @@ public class TurboConfig {
 
     public final boolean enabled;
     public final String ignoreChangesInFiles;
+    public final String includeTopDirectories;
+    public final String excludeTopDirectories;
 
     public final String alwaysBuildModules;
     public final String m2Repository;
@@ -31,6 +30,8 @@ public class TurboConfig {
         String configAsXml = plugin.getConfiguration() != null ? plugin.getConfiguration().toString() : "";
         ignoreChangesInFiles = getParameter(configAsXml, "ignoreChangesInFiles", "");
         alwaysBuildModules = getParameter(configAsXml, "alwaysBuildModules", "");
+        includeTopDirectories = getParameter(configAsXml, "includeTopDirectories", "src");
+        excludeTopDirectories = getParameter(configAsXml, "excludeTopDirectories", "");
 
         m2Repository = session.getLocalRepository().getBasedir();
 

--- a/src/main/java/no/sparebank1/turbo/extension/TurboBuildWrapper.java
+++ b/src/main/java/no/sparebank1/turbo/extension/TurboBuildWrapper.java
@@ -50,7 +50,7 @@ public class TurboBuildWrapper extends AbstractMavenLifecycleParticipant {
 
                 List<MavenProject> projects = session.getProjects();
 
-                List<MavenProject> projectsToBuild = projectsAnalyzer.calculateProjectsToBuild(config.m2Repository, projects, session.getProjectDependencyGraph(), config.ignoreChangesInFiles, config.alwaysBuildModules);
+                List<MavenProject> projectsToBuild = projectsAnalyzer.calculateProjectsToBuild(config.m2Repository, projects, session.getProjectDependencyGraph(), config.ignoreChangesInFiles, config.alwaysBuildModules, config.includeTopDirectories, config.excludeTopDirectories);
 
                 session.setProjects(projectsToBuild);
 
@@ -92,7 +92,7 @@ public class TurboBuildWrapper extends AbstractMavenLifecycleParticipant {
                 projects.forEach(project -> {
                     //Write the checksums when we have a successful build:
                     if(session.getResult().getBuildSummary(project).toString().toLowerCase().contains("success")) {
-                        List<String> sourceFiles = new SourceFileFinder().getSourceFiles(project.getBasedir().getAbsolutePath(), config.ignoreChangesInFiles);
+                        List<String> sourceFiles = new SourceFileFinder().getSourceFiles(project.getBasedir().getAbsolutePath(), project.getModules(), config.ignoreChangesInFiles, config.includeTopDirectories, config.excludeTopDirectories);
                         new Checksums().createAndWriteChecksums(config.m2Repository, sourceFiles, project.getGroupId(), project.getArtifactId(), project.getVersion());
                     }
                 });

--- a/src/test/java/no/sparebank1/turbo/ProjectsAnalyzerTest.java
+++ b/src/test/java/no/sparebank1/turbo/ProjectsAnalyzerTest.java
@@ -27,7 +27,7 @@ public class ProjectsAnalyzerTest {
   @Test
   public void project_D_shall_have_A_B_C_as_downstream_dependencies() {
 
-    List<MavenProject> projectsToBuild = projectAnalyzer.calculateProjectsToBuild("", getProjects(), projectDependencyGraph, "", "D");
+    List<MavenProject> projectsToBuild = projectAnalyzer.calculateProjectsToBuild("", getProjects(), projectDependencyGraph, "", "D", "src", "");
     assertEquals(4, projectsToBuild.size());
     assertTrue(projectsToBuild.contains(getMavenProjectWithArtifactId("A")) &&
       projectsToBuild.contains(getMavenProjectWithArtifactId("B")) &&
@@ -37,7 +37,7 @@ public class ProjectsAnalyzerTest {
 
   @Test
   public void project_C_shall_have_A_as_downstream_dependency() {
-    List<MavenProject> projectsToBuild = projectAnalyzer.calculateProjectsToBuild("", getProjects(), projectDependencyGraph, "", "C");
+    List<MavenProject> projectsToBuild = projectAnalyzer.calculateProjectsToBuild("", getProjects(), projectDependencyGraph, "", "C", "src", "");
     assertEquals(2, projectsToBuild.size());
     assertTrue(projectsToBuild.contains(getMavenProjectWithArtifactId("A")) &&
       projectsToBuild.contains(getMavenProjectWithArtifactId("C")));
@@ -45,7 +45,7 @@ public class ProjectsAnalyzerTest {
 
   @Test
   public void project_B_shall_have_A_as_downstream_dependency() {
-    List<MavenProject> projectsToBuild = projectAnalyzer.calculateProjectsToBuild("", getProjects(), projectDependencyGraph, "", "B");
+    List<MavenProject> projectsToBuild = projectAnalyzer.calculateProjectsToBuild("", getProjects(), projectDependencyGraph, "", "B", "src", "");
     assertEquals(2, projectsToBuild.size());
     assertTrue(projectsToBuild.contains(getMavenProjectWithArtifactId("A")) &&
       projectsToBuild.contains(getMavenProjectWithArtifactId("B")));
@@ -53,7 +53,7 @@ public class ProjectsAnalyzerTest {
 
   @Test
   public void project_A_shall_have_no_downstream_dependencies() {
-    List<MavenProject> projectsToBuild = projectAnalyzer.calculateProjectsToBuild("", getProjects(), projectDependencyGraph, "", "A");
+    List<MavenProject> projectsToBuild = projectAnalyzer.calculateProjectsToBuild("", getProjects(), projectDependencyGraph, "", "A", "src", "");
     assertEquals(1, projectsToBuild.size());
     assertTrue(projectsToBuild.contains(getMavenProjectWithArtifactId("A")));
   }

--- a/src/test/java/no/sparebank1/turbo/SourceFileFinderTest.java
+++ b/src/test/java/no/sparebank1/turbo/SourceFileFinderTest.java
@@ -3,6 +3,7 @@ package no.sparebank1.turbo;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -11,7 +12,7 @@ class SourceFileFinderTest {
     @Test
     public void shall_find_all_files_in_subdirectories() {
         String path = new File(".").getAbsolutePath() + "/src/test/foo";
-        List<String> sourcefiles = new SourceFileFinder().getSourceFiles(path, "");
+        List<String> sourcefiles = new SourceFileFinder().getSourceFiles(path, new ArrayList<String>(), ".jar", "", "");
         assertTrue(true);
     }
 }

--- a/src/test/java/no/sparebank1/turbo/stubs/ProjectsAnalyzerStub.java
+++ b/src/test/java/no/sparebank1/turbo/stubs/ProjectsAnalyzerStub.java
@@ -12,7 +12,7 @@ public class ProjectsAnalyzerStub extends ProjectsAnalyzer {
   }
 
   @Override
-  protected boolean shallBuildProject(final String m2Repository, final MavenProject project, final String ignoreChangesInFiles, final String alwaysBuildModules) {
+  protected boolean shallBuildProject(final String m2Repository, final MavenProject project, final String ignoreChangesInFiles, final String alwaysBuildModules, final String includeTopDirectories, final String excludeTopDirectories) {
     if (alwaysBuildModules.contains(project.getArtifactId())) {
       return true;
     }

--- a/src/test/java/no/sparebank1/turbo/stubs/SourceFileFinderStub.java
+++ b/src/test/java/no/sparebank1/turbo/stubs/SourceFileFinderStub.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public class SourceFileFinderStub extends SourceFileFinder {
   @Override
-  public List<String> getSourceFiles(final String projectRoot, final String ignoreChangesInFiles) {
+  public List<String> getSourceFiles(final String projectRoot, final List<String> mvnChildModules, final String ignoreChangesInFiles, final String includeTopDirectories, final String excludeTopDirectories) {
     return new ArrayList<String>();
   }
 }


### PR DESCRIPTION
In previous version, only src directory is included in check.
Changed it so that it is configurable which "top" directories under pom project (parent and child) is included in check.
If parameter is not used in plugin config, default will be src as before.
Also added a plugin config in order to exclude given directories.